### PR TITLE
Remove use of UUID

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,6 @@
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.3",
-        "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.3",
-    "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,7 +1,6 @@
 import { Component } from "react";
 import { assertTrue, getHeaderStyle, arraysOrderAreEqual, Reorder, IMAGE_PIXEL_LENGTH, FRAME_PIXEL_COUNT } from "../utils"
 import { DragDropContext } from "react-beautiful-dnd";
-import { v4 as uuid } from 'uuid';
 import FrameList from "./FrameList";
 
 class Header extends Component {
@@ -78,8 +77,8 @@ class Header extends Component {
             return;
         }
         const newAnimation = {
-            name: uuid(),
-            frameDuration: 2,
+            name: 'ID' + new Date().getTime(),
+            frameDuration: 500,
             repeatCount: 3,
             frames: this.state.frames
         }

--- a/client/src/components/Switch.js
+++ b/client/src/components/Switch.js
@@ -1,21 +1,19 @@
 import React from 'react';
-import { v4 as uuid } from 'uuid';
 
-const Switch = ({ isOn, handleToggle }) => {
-    const ID = uuid();
+const Switch = ({ isOn, handleToggle, name }) => {
     return (
         <>
             <input
                 checked={isOn}
                 onChange={handleToggle}
                 className="react-switch-checkbox"
-                id={`react-switch-new` + ID}
+                id={`react-switch-new` + name}
                 type="checkbox"
             />
             <label
                 style={{ background: isOn && '#06D6A0' }}
                 className="react-switch-label"
-                htmlFor={`react-switch-new` + ID}
+                htmlFor={`react-switch-new` + name}
             >
                 <span className={`react-switch-button`} />
             </label>

--- a/client/src/components/WholeBox.js
+++ b/client/src/components/WholeBox.js
@@ -27,7 +27,7 @@ const WholeBox = (props) => {
                     <div ref={provided.innerRef} {...provided.draggableProps} style={getItemStyle(snapshot.isDragging, provided.draggableProps.style)} >
                         <Animation data={animationData} />
                         <FrameList animationData={animationData} animationIndex={index} dragSwitch={value} />
-                        <Switch isOn={value} handleToggle={() => setValue(!value)} />
+                        <Switch isOn={value} handleToggle={() => setValue(!value)} name={animationData.name} />
                         <img src={trashIcon} width={26} height={39} style={trashIconStyle} onClick={() => removeFromAnimationList(animationData.name)} alt="trashbin" />
                     </div>
                 </span>


### PR DESCRIPTION
Fixes: #33 

Looks like something with the long UUID was messing with the creation of the animation. Maybe it was too long for the CSS or something. Moved to something more simple which is just "ID" with the timestamp appended which is unique enough for this case.