### PR TITLE
Add archive and delete actions for catalog animations

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -34,6 +34,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
   padding: 20px;
   background-color: var(--header-background-color);
   color: var(--header-text-color);
@@ -110,4 +112,144 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+}
+
+.CatalogBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.65);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.CatalogContent {
+  background: #ffffff;
+  max-width: 90vw;
+  width: 900px;
+  max-height: 80vh;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.CatalogHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.CatalogHeaderRow h2 {
+  margin: 0;
+  color: #333333;
+}
+
+.CatalogCloseButton {
+  min-width: 40px;
+}
+
+.CatalogStatus {
+  text-align: center;
+  color: #444444;
+  padding: 40px 0;
+  font-size: 1rem;
+}
+
+.CatalogGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.CatalogCard {
+  background: var(--container-background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.CatalogPreview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #000000;
+  border-radius: 8px;
+  min-height: 180px;
+  overflow: hidden;
+}
+
+.CatalogPlaceholder {
+  color: #dddddd;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.CatalogDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.CatalogTitle {
+  font-weight: bold;
+  word-break: break-word;
+}
+
+.CatalogMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: #555555;
+}
+
+.CatalogActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.CatalogAddButton {
+  flex: 2 1 160px;
+}
+
+.CatalogAddButton:disabled {
+  cursor: not-allowed;
+  background-color: #e0e0e0;
+  color: #7a7a7a;
+}
+
+.CatalogArchiveButton {
+  flex: 1 1 120px;
+}
+
+.CatalogDeleteButton {
+  flex: 1 1 120px;
+  background-color: #c0392b;
+  border-color: #c0392b;
+}
+
+.CatalogDeleteButton:hover:not(:disabled) {
+  background-color: #962d22;
+  border-color: #962d22;
+}
+
+.CatalogDeleteButton:focus-visible {
+  outline: 3px solid rgba(192, 57, 43, 0.35);
+  outline-offset: 2px;
 }

--- a/client/src/components/CatalogModal.js
+++ b/client/src/components/CatalogModal.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import Animation from './Animation';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faTimes, faArchive, faTrash } from '@fortawesome/free-solid-svg-icons';
+
+const CatalogModal = ({
+  animations,
+  frames,
+  queueAnimationIDs,
+  onClose,
+  onAddToQueue,
+  onArchiveAnimation,
+  onDeleteAnimation,
+  isLoading,
+}) => {
+  const animationIdSet = queueAnimationIDs instanceof Set ? queueAnimationIDs : new Set(queueAnimationIDs);
+
+  return (
+    <div className="CatalogBackdrop" role="dialog" aria-modal="true">
+      <div className="CatalogContent">
+        <div className="CatalogHeaderRow">
+          <h2>Animation Catalog</h2>
+          <button className="button CatalogCloseButton" onClick={onClose} title="Close catalog">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+        {isLoading ? (
+          <div className="CatalogStatus">Loading catalog previews&hellip;</div>
+        ) : animations.length === 0 ? (
+          <div className="CatalogStatus">No saved animations are available yet.</div>
+        ) : (
+          <div className="CatalogGrid">
+            {animations.map((animation) => {
+              const frameOrder = animation.frameOrder || [];
+              const isQueued = animationIdSet.has(animation.animationID);
+              const hasFrames = frameOrder.every((frameId) => frames.has(frameId));
+
+              return (
+                <div className="CatalogCard" key={animation.animationID}>
+                  <div className="CatalogPreview">
+                    {hasFrames ? (
+                      <Animation metadata={animation} frames={frames} samplingTechnique="catalog" />
+                    ) : (
+                      <div className="CatalogPlaceholder">Preview loading&hellip;</div>
+                    )}
+                  </div>
+                  <div className="CatalogDetails">
+                    <div className="CatalogTitle">{animation.animationID}</div>
+                    <div className="CatalogMeta">
+                      <span>{frameOrder.length} frame{frameOrder.length === 1 ? '' : 's'}</span>
+                      <span>{animation.frameDuration} ms / frame</span>
+                      <span>Repeats: {animation.repeatCount}</span>
+                    </div>
+                    <div className="CatalogActions">
+                      <button
+                        className="button CatalogAddButton"
+                        onClick={() => onAddToQueue(animation)}
+                        disabled={isQueued || !hasFrames}
+                        title={isQueued ? 'Animation already in the queue' : 'Add animation to the queue'}
+                      >
+                        {isQueued ? 'In Queue' : (
+                          <>
+                            Add to Queue&nbsp;
+                            <FontAwesomeIcon icon={faPlus} />
+                          </>
+                        )}
+                      </button>
+                      <button
+                        className="button CatalogArchiveButton"
+                        onClick={() => onArchiveAnimation(animation.animationID)}
+                        title="Archive this animation"
+                      >
+                        Archive&nbsp;
+                        <FontAwesomeIcon icon={faArchive} />
+                      </button>
+                      <button
+                        className="button CatalogDeleteButton"
+                        onClick={() => onDeleteAnimation(animation.animationID)}
+                        title="Delete this animation permanently"
+                      >
+                        Delete&nbsp;
+                        <FontAwesomeIcon icon={faTrash} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CatalogModal;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,11 +1,14 @@
 import { Component } from "react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSave, faPlusSquare } from "@fortawesome/free-solid-svg-icons";
+import { faSave, faPlusSquare, faList } from "@fortawesome/free-solid-svg-icons";
 
 class Header extends Component {
     render() {
         return (
             <div className="Header">
+                <button onClick={this.props.openCatalog} className="button" title="Browse animation catalog">
+                    Catalog&nbsp;<FontAwesomeIcon icon={faList} />
+                </button>
                 <button onClick={this.props.openModalForNewAnimation} className="button" title="Add new animation">
                     New Animation&nbsp;<FontAwesomeIcon icon={faPlusSquare} />
                 </button>

--- a/client/src/components/WholeBox.js
+++ b/client/src/components/WholeBox.js
@@ -13,7 +13,7 @@ const WholeBox = (props) => {
                 <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} style={getItemStyle(snapshot.isDragging, provided.draggableProps.style)}>
                     <div className="wholeBox">
                         <div className="animation-container">
-                            <Animation metadata={metadata} frames={frames} />
+                            <Animation metadata={metadata} frames={frames} samplingTechnique="queue" />
                         </div>
                         <div className="controls-container">
                             <div className="drag-handle">

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -151,6 +151,36 @@ export const fetchMetadataFromServer = async () => {
     return data.metadata;
 }
 
+export const fetchCatalogFromServer = async () => {
+    const endpoint = SERVER_ROOT_URL + 'catalog';
+    console.debug('GET request for catalog from server. Endpoint: ' + endpoint);
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    console.debug('Catalog received: ' + JSON.stringify(data));
+    return data.animations || [];
+}
+
+export const archiveCatalogAnimationOnServer = async (animationID) => {
+    const endpoint = SERVER_ROOT_URL + `catalog/${encodeURIComponent(animationID)}/archive`;
+    console.debug('POST request to archive catalog animation. Endpoint: ' + endpoint);
+    const response = await fetch(endpoint, { method: 'POST' });
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+}
+
+export const deleteCatalogAnimationFromServer = async (animationID) => {
+    const endpoint = SERVER_ROOT_URL + `catalog/${encodeURIComponent(animationID)}`;
+    console.debug('DELETE request to remove catalog animation. Endpoint: ' + endpoint);
+    const response = await fetch(endpoint, { method: 'DELETE' });
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+}
+
 /**
  * @param {*} frameID the unique ID of the frame to fetch
  * @returns the frame data as a Uint8Array from the server

--- a/server/db/catalogOperations.ts
+++ b/server/db/catalogOperations.ts
@@ -1,0 +1,72 @@
+import { Metadata } from '../Metadata';
+import AnimationCatalogModel from './schemas/catalog-animation-schema';
+import ArchivedAnimationCatalogModel from './schemas/catalog-archived-animation-schema';
+
+const fetchAnimationCatalog = async (): Promise<Metadata[]> => {
+  try {
+    const catalogDocuments = await AnimationCatalogModel.find({}, '-_id animationID frameDuration repeatCount frameOrder').lean();
+    return catalogDocuments.map((doc) => new Metadata(doc.animationID, doc.frameDuration, doc.repeatCount, doc.frameOrder));
+  } catch (error) {
+    console.error('Error fetching animation catalog:', error);
+    throw error;
+  }
+};
+
+const upsertCatalogEntries = async (metadataEntries: Metadata[]) => {
+  try {
+    const operations = metadataEntries.map((metadata) => (
+      AnimationCatalogModel.findOneAndUpdate(
+        { animationID: metadata.animationID },
+        {
+          animationID: metadata.animationID,
+          frameDuration: metadata.frameDuration,
+          repeatCount: metadata.repeatCount,
+          frameOrder: metadata.frameOrder,
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      )
+    ));
+
+    await Promise.all(operations);
+  } catch (error) {
+    console.error('Error upserting animation catalog entries:', error);
+    throw error;
+  }
+};
+
+const archiveCatalogEntry = async (animationID: string): Promise<boolean> => {
+  try {
+    const catalogEntry = await AnimationCatalogModel.findOne({ animationID }).lean();
+
+    if (!catalogEntry) {
+      return false;
+    }
+
+    const { _id, ...entryWithoutId } = catalogEntry;
+
+    await ArchivedAnimationCatalogModel.findOneAndUpdate(
+      { animationID: entryWithoutId.animationID },
+      { ...entryWithoutId, archivedAt: new Date() },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    await AnimationCatalogModel.deleteOne({ animationID });
+
+    return true;
+  } catch (error) {
+    console.error('Error archiving animation catalog entry:', error);
+    throw error;
+  }
+};
+
+const deleteCatalogEntry = async (animationID: string): Promise<boolean> => {
+  try {
+    const result = await AnimationCatalogModel.deleteOne({ animationID });
+    return result.deletedCount !== undefined && result.deletedCount > 0;
+  } catch (error) {
+    console.error('Error deleting animation catalog entry:', error);
+    throw error;
+  }
+};
+
+export { fetchAnimationCatalog, upsertCatalogEntries, archiveCatalogEntry, deleteCatalogEntry };

--- a/server/db/schemas/catalog-animation-schema.ts
+++ b/server/db/schemas/catalog-animation-schema.ts
@@ -1,0 +1,37 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+interface IAnimationCatalog extends Document {
+  animationID: string;
+  frameDuration: number;
+  repeatCount: number;
+  frameOrder: string[];
+  createdAt: Date;
+}
+
+const AnimationCatalogSchema = new Schema<IAnimationCatalog>({
+  animationID: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  frameDuration: {
+    type: Number,
+    required: true,
+  },
+  repeatCount: {
+    type: Number,
+    required: true,
+  },
+  frameOrder: {
+    type: [String],
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const AnimationCatalogModel = mongoose.model<IAnimationCatalog>('AnimationCatalog', AnimationCatalogSchema);
+
+export default AnimationCatalogModel;

--- a/server/db/schemas/catalog-archived-animation-schema.ts
+++ b/server/db/schemas/catalog-archived-animation-schema.ts
@@ -1,0 +1,42 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+interface IArchivedAnimationCatalog extends Document {
+  animationID: string;
+  frameDuration: number;
+  repeatCount: number;
+  frameOrder: string[];
+  createdAt: Date;
+  archivedAt: Date;
+}
+
+const ArchivedAnimationCatalogSchema = new Schema<IArchivedAnimationCatalog>({
+  animationID: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  frameDuration: {
+    type: Number,
+    required: true,
+  },
+  repeatCount: {
+    type: Number,
+    required: true,
+  },
+  frameOrder: {
+    type: [String],
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    required: true,
+  },
+  archivedAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const ArchivedAnimationCatalogModel = mongoose.model<IArchivedAnimationCatalog>('ArchivedAnimationCatalog', ArchivedAnimationCatalogSchema);
+
+export default ArchivedAnimationCatalogModel;


### PR DESCRIPTION
## Summary
- add archive and delete controls to the catalog modal so animations can be removed or archived from the UI
- expose client utilities and backend endpoints that archive catalog entries or permanently delete them
- persist archived animations in MongoDB using a dedicated schema to retain data before removal

## Testing
- npm run build-client
- npm run build-server

------
https://chatgpt.com/codex/tasks/task_e_68d9b5d3e6f0832f885ebf97919e820c